### PR TITLE
binder: install pycairo, use this repo to install the extension from.

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,2 +1,3 @@
 cairocffi
--e git+https://github.com/stuaxo/cairo-jupyter.git#egg=cairo-jupyter
+pycairo
+-e git+https://github.com/fomightez/cairo-jupyter.git#egg=cairo-jupyter


### PR DESCRIPTION
Move to this repo (we really need to move to pypi next though)
Install pycairo - we should probably demo cairocffi and pycairo (mostly pycairo, with cairocffi as an alternative).


note:  If binder stops working after installing this, it may be because there are unmerged changes, pretty sure there aren't  but it's been a while since I tested things.