### PR TITLE
Feature/fix install

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
-# postBuild runs with cwd at the project root
+# NOTE:  postBuild runs with cwd at the project root
 #
-jupyter nbextension enable cairo_jupyter
+# Install cairo_jupyter extension:
+pip install .
+# Trust the notebooks:
 jupyter trust index.ipynb demos/*.ipynb

--- a/extension/cairo_jupyter/__init__.py
+++ b/extension/cairo_jupyter/__init__.py
@@ -5,60 +5,71 @@ import logging
 import os
 
 from io import BytesIO
-from IPython.core import display
+from IPython import display, get_ipython
 
 CAIRO_JUPYTER_LOG = "CAIRO_JUPYTER_LOG"
 
+
 def setup_logging():
-    logger = logging.getLogger("CAIRO_JUPYTER_LOG")
-    level = os.environ.get(CAIRO_JUPYTER_LOG) 
-    if level in ['debug', 'info', 'warning', 'error']:
+    logger = logging.getLogger(CAIRO_JUPYTER_LOG)
+    level = os.environ.get(CAIRO_JUPYTER_LOG)
+    if level in ["debug", "info", "warning", "error"]:
         logger.setLevel(level)
+    elif level == "1":
+        logger.setLevel(logging.DEBUG)
     else:
-        logger.addHandler(logging.NullHandler())
+        logger.setLevel(logging.ERROR)
 
 
-def display_cairo_surface(surface):
-    """Displayhook function for Surfaces Images, rendered as PNG."""
-    b = BytesIO()
+def cairo_surface_as_png_data(surface):
+    """
+    Render surface with write_to_png and return the data
+    so that PNGFormatter can render it.
+    """
+    # Fill buffer with png data then rewind buffer to start
+    buffer = BytesIO()
+    surface.write_to_png(buffer)
+    buffer.seek(0)
 
-    surface.write_to_png(b)
-    b.seek(0)
-    data = b.read()
-
-    ip_img = display.Image(data=data, format='png', embed=True)
-    return ip_img._repr_png_()
+    return buffer.read()
 
 
-def display_cairo_context(ctx):
-    """Displayhook function for cairo Context Images, target is rendered as PNG."""
-    surface = ctx.get_target()
-    return display_cairo_surface(surface)
-
+def cairo_context_as_png_data(context):
+    """
+    Get the target surface and render to png, return data
+    suitable for PNGFormatter to render.
+    """
+    surface = context.get_target()
+    return cairo_surface_as_png_data(surface)
 
 
 def load_ipython_extension(ipython):
     # register display func with PNG formatter:
-    png_formatter = get_ipython().display_formatter.formatters['image/png']
+    png_formatter = get_ipython().display_formatter.formatters["image/png"]
     try:
         import cairo
-        png_formatter.for_type(cairo.Surface, display_cairo_surface)
-        png_formatter.for_type(cairo.Context, display_cairo_context)
     except ImportError:
         cairo = None
         logger.debug("import cairocffi failed")
+    else:
+        png_formatter.for_type(cairo.Surface, cairo_surface_as_png_data)
+        png_formatter.for_type(cairo.Context, cairo_context_as_png_data)
 
     try:
         import cairocffi
-        png_formatter.for_type(cairocffi.surfaces.ImageSurface, display_cairo_surface)
-        png_formatter.for_type(cairocffi.Surface, display_cairo_surface)
-        png_formatter.for_type(cairocffi.Context, display_cairo_context)
     except ImportError:
         cairocffi = None
         logger.debug("import cairocffi failed")
+    else:
+        png_formatter.for_type(
+            cairocffi.surfaces.ImageSurface, cairo_surface_as_png_data
+        )
+        png_formatter.for_type(cairocffi.Surface, cairo_surface_as_png_data)
+        png_formatter.for_type(cairocffi.Context, cairo_context_as_png_data)
 
     if not any([cairo, cairocffi]):
-        logger.error("Cairo or CairoCFFI not found")
+        logger.error("Cairo or CairoCFFI not found.")
+
 
 def unload_ipython_extension(ipython):
     pass

--- a/extension/cairo_jupyter/static/index.js
+++ b/extension/cairo_jupyter/static/index.js
@@ -1,0 +1,13 @@
+// cairo_jupyter doesn't have any JS code.
+//
+// This file is added to make Jupyter happy so it will load the extension.
+define(function(){
+
+    function load_ipython_extension(){
+        console.info('loaded cairo_jupyter.');
+    }
+
+    return {
+        load_ipython_extension: load_ipython_extension
+    };
+});

--- a/jupyter-config/jupyter_notebook_config.d/cairo_jupyter.json
+++ b/jupyter-config/jupyter_notebook_config.d/cairo_jupyter.json
@@ -1,0 +1,7 @@
+{
+    "NotebookApp": {
+        "nbserver_extensions": {
+            "cairo_jupyter": true
+        }
+    }
+}

--- a/jupyter-config/nbconfig/notebook.d/cairo_jupyter.json
+++ b/jupyter-config/nbconfig/notebook.d/cairo_jupyter.json
@@ -1,0 +1,5 @@
+{
+    "load_extensions": {
+        "cairo_jupyter/index": true
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,35 @@
 # -*- coding: utf-8 -*-
-from setuptools import find_packages
-from setuptools import setup
+#
+# For more info on Jupyter setup.py see:
+# https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Distributing%20Jupyter%20Extensions%20as%20Python%20Packages.html
+#
+from setuptools import find_packages, setup
 
-setup_kwargs=dict(
-    name='cairo-jupyter',
-    packages=find_packages('extension'),
-    package_dir={'': 'extension'},
-    install_requires=["jupyter-pip"],
+setup(
+    name="cairo-jupyter",
+    version="0.0.2",
+    include_package_data=True,
+    packages=find_packages("extension"),
+    package_dir={"": "extension"},
     setup_requires=["pytest-runner"],
     tests_require=["pytest", "nbval"],
+    zip_safe=False,
+    data_files=[
+        # like `jupyter nbextension install --sys-prefix`
+        (
+            "share/jupyter/nbextensions/cairo_jupyter",
+            ["extension/cairo_jupyter/static/index.js"],
+        ),
+        # like `jupyter nbextension enable --sys-prefix`
+        (
+            "etc/jupyter/nbconfig/notebook.d",
+            ["jupyter-config/nbconfig/notebook.d/cairo_jupyter.json"],
+        ),
+        # like `jupyter serverextension enable --sys-prefix`
+        (
+            "etc/jupyter/jupyter_notebook_config.d",
+            ["jupyter-config/jupyter_notebook_config.d/cairo_jupyter.json"],
+        ),
+    ],
 )
-
-try:
-    from jupyterpip import cmdclass
-    setup_params['cmdclass'] = jupyterpip
-except:
-    cmdclass=setup
-
-setup(**setup_kwargs)
-
-
 


### PR DESCRIPTION
Fixes the binder issue where the extension couldn't be enabled.
Fixes the validation issue.

So now, with `%reload_ext cairo_jupyter` in a cell near the top, you can call `display(surface)` to output the surface.

Making things a lot more useful.

In the meantime Jupyter have made it possible for installation to = enabling the extension, so installing with `pip` is enough to get things up and running.